### PR TITLE
Bump jacoco version for Java 11 Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.1</version>
+                    <version>0.8.2</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
JaCoCo version 0.8.2 supports Java 11